### PR TITLE
Track time gap setting and read CAN commands to change it

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -121,20 +121,8 @@ struct CarState {
   doorOpen @24 :Bool;
   seatbeltUnlatched @25 :Bool;
 
-  # added to support https://github.com/rhinodavid/OpenpilotButtons
-  timeGap @26 :CommaButtonTimeGap;
-
   # which packets this state came from
   canMonoTimes @12: List(UInt64);
-
-  # commanded and set follow distance
-  # see https://github.com/rhinodavid/OpenpilotButtons
-  enum CommaButtonTimeGap {
-    unknown @0;
-    near @1;
-    medium @2;
-    far @3;
-  }
 
   struct WheelSpeeds {
     # optional wheel speeds
@@ -150,6 +138,15 @@ struct CarState {
     available @2 :Bool;
     speedOffset @3 :Float32;
     standstill @4 :Bool;
+    # added to support OpenpilotButtons -- https://github.com/rhinodavid/OpenpilotButtons
+    timeGap @5 :TimeGap;
+  }
+  
+  enum TimeGap {
+    unknown @0;
+    near @1;
+    medium @2;
+    far @3;
   }
 
   enum GearShifter {
@@ -178,6 +175,8 @@ struct CarState {
       altButton1 @6;
       altButton2 @7;
       altButton3 @8;
+      # added to support OpenpilotButtons -- https://github.com/rhinodavid/OpenpilotButtons
+      accTimeGapButton @9; # button that changes how closely the ACC follows the car in front of it
     }
   }
 }
@@ -247,6 +246,8 @@ struct CarControl {
     override @1: Bool;
     speedOverride @2: Float32;
     accelOverride @3: Float32;
+    # Added to support Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    advanceTimeGap @4: Bool; # True if HUD is showing wrong time gap and needs to be advanced
   }
 
   struct HUDControl {

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -124,7 +124,7 @@ class CarController(object):
     self.packer = CANPacker(dbc_name)
 
   def update(self, sendcan, enabled, CS, frame, actuators,
-             pcm_cancel_cmd, hud_alert, audible_alert, forwarding_camera, left_line, right_line, lead):
+             pcm_cancel_cmd, hud_alert, audible_alert, forwarding_camera, left_line, right_line, lead, advance_time_gap = False):
 
     # *** compute control surfaces ***
 
@@ -214,8 +214,10 @@ class CarController(object):
     elif ECU.APGS in self.fake_ecus:
       can_sends.append(create_ipas_steer_command(self.packer, 0, 0, True))
 
-    # Comma Buttons https://github.com/rhinodavid/CommaButtons
-    distance = 1 if CS.acc_needs_advance else 0
+    # added to support OpenpilotButtons -- https://github.com/rhinodavid/OpenpilotButtons
+    # check to see if the number of time gap lines displayed by the car matches the number
+    # we are trying to command. if they are different, send a distance of 1 to change the displayed number of lines
+    distance = 1 if advance_time_gap else 0
 
     # accel cmd comes from DSU, but we can spam can to cancel the system even if we are using lat only control
     if (frame % 3 == 0 and ECU.DSU in self.fake_ecus) or (pcm_cancel_cmd and ECU.CAM in self.fake_ecus):

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -47,8 +47,8 @@ def get_can_parser(CP):
     ("IPAS_STATE", "EPS_STATUS", 1),
     ("BRAKE_LIGHTS_ACC", "ESP_CONTROL", 0),
     ("AUTO_HIGH_BEAM", "LIGHT_STALK", 0),
-    # Add the following two values for https://github.com/rhinodavid/CommaButtons
-    ("ACC_DISTANCE", "COMMA_BUTTONS", 0),
+    # Add the following two values for https://github.com/rhinodavid/OpenpilotButtons
+    ("ACC_TIME_GAP", "OPENPILOT_BUTTONS", 0),
     ("DISTANCE_LINES", "PCM_CRUISE_SM", 0),
   ]
 
@@ -93,15 +93,6 @@ class CarState(object):
     self.left_blinker_on = 0
     self.right_blinker_on = 0
 
-    # Comma Buttons -- see https://github.com/rhinodavid/CommaButtons
-    self.acc_needs_advance = False
-    self.button_press_read_lines = 0
-    self.commanded_time_gap = 1 # 1: far, 2: medium, 3: close
-    # prev_acc_button_state [0|1] changes based on Follow Distance button presses
-    # ex: 0...0...0...[button press]...1...1...1...[button press]...0...0...0
-    self.prev_acc_button_state = 0
-    self.read_distance_lines = 0
-
     # initialize can parser
     self.car_fingerprint = CP.carFingerprint
 
@@ -114,6 +105,13 @@ class CarState(object):
                          C=np.matrix([1.0, 0.0]),
                          K=np.matrix([[0.12287673], [0.29666309]]))
     self.v_ego = 0.0
+
+    # Added to support Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    # prev_time_gap_button_state [0|1] changes based on ACC Time Gap button presses
+    # ex: 0...0...0...[button press]...1...1...1...[button press]...0...0...0
+    self.prev_time_gap_button_state = 0
+    self.read_distance_lines = 0
+    self.time_gap_button_pressed = False
 
   def update(self, cp, cp_cam):
     # copy can_valid
@@ -183,21 +181,8 @@ class CarState(object):
     else:
       self.generic_toggle = bool(cp.vl["LIGHT_STALK"]['AUTO_HIGH_BEAM'])
     
-    # added to support https://github.com/rhinodavid/CommaButtons
-    new_acc_button_state = cp.vl["COMMA_BUTTONS"]['ACC_DISTANCE']
+    # Added to support Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    time_gap_button_state = cp.vl["OPENPILOT_BUTTONS"]['ACC_TIME_GAP']
     self.read_distance_lines = cp.vl["PCM_CRUISE_SM"]['DISTANCE_LINES']
-
-    if new_acc_button_state != self.prev_acc_button_state:
-      # we've detected a press of the ACC button
-      self.prev_acc_button_state = new_acc_button_state
-      # only try to change the follow distance if cruise control is active
-      if self.pcm_acc_active:
-        # save the read_lines value. we'll tell the vehicle to update the distance until we
-        # observe the read distance lines change
-        self.button_press_read_lines = self.read_distance_lines
-        self.acc_needs_advance = True
-    
-    if self.acc_needs_advance and self.read_distance_lines != self.button_press_read_lines:
-      # ACC distance setting has been advanced
-      self.acc_needs_advance = False
-      self.commanded_time_gap = self.read_distance_lines
+    self.time_gap_button_pressed = time_gap_button_state != self.prev_time_gap_button_state
+    self.prev_time_gap_button_state = time_gap_button_state

--- a/selfdrive/car/toyota/interface.py
+++ b/selfdrive/car/toyota/interface.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
   CarController = None
 
-
 class CarInterface(object):
   def __init__(self, CP, sendcan=None):
     self.CP = CP
@@ -270,16 +269,8 @@ class CarInterface(object):
     ret.cruiseState.available = bool(self.CS.main_on)
     ret.cruiseState.speedOffset = 0.
 
-    # comma buttons
-    # see https://github.com/rhinodavid/CommmaButtons
-    if self.CS.commanded_time_gap == 3:
-      ret.timeGap = car.CarState.CommaButtonTimeGap.far
-    elif self.CS.commanded_time_gap == 2:
-      ret.timeGap = car.CarState.CommaButtonTimeGap.medium
-    elif self.CS.commanded_time_gap == 1:
-      ret.timeGap = car.CarState.CommaButtonTimeGap.near
-    else:
-      ret.timeGap = car.CarState.CommaButtonTimeGap.unknown
+    # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    ret.cruiseState.timeGap = TimeGaps.from_toyota_distance_lines(self.CS.read_distance_lines)
 
     if self.CP.carFingerprint in [CAR.RAV4H, CAR.HIGHLANDERH, CAR.HIGHLANDER] or self.CP.enableGasInterceptor:
       # ignore standstill in hybrid vehicles, since pcm allows to restart without
@@ -300,6 +291,13 @@ class CarInterface(object):
       be = car.CarState.ButtonEvent.new_message()
       be.type = 'rightBlinker'
       be.pressed = self.CS.right_blinker_on != 0
+      buttonEvents.append(be)
+
+    # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    if self.CS.time_gap_button_pressed:
+      be = car.CarState.ButtonEvent.new_message()
+      be.type = 'accTimeGapButton'
+      be.pressed = True
       buttonEvents.append(be)
 
     ret.buttonEvents = buttonEvents
@@ -380,7 +378,8 @@ class CarInterface(object):
     self.CC.update(self.sendcan, c.enabled, self.CS, self.frame,
                    c.actuators, c.cruiseControl.cancel, c.hudControl.visualAlert,
                    c.hudControl.audibleAlert, self.forwarding_camera,
-                   c.hudControl.leftLaneVisible, c.hudControl.rightLaneVisible, c.hudControl.leadVisible)
+                   c.hudControl.leftLaneVisible, c.hudControl.rightLaneVisible,
+                   c.hudControl.leadVisible, c.cruiseControl.advanceTimeGap)
 
     self.frame += 1
     return False

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,7 +16,8 @@ from selfdrive.controls.lib.drive_helpers import learn_angle_offset, \
                                                  create_event, \
                                                  EventTypes as ET, \
                                                  update_v_cruise, \
-                                                 initialize_v_cruise
+                                                 initialize_v_cruise, \
+                                                 TimeGaps
 from selfdrive.controls.lib.longcontrol import LongControl, STARTING_TARGET_SPEED
 from selfdrive.controls.lib.latcontrol import LatControl
 from selfdrive.controls.lib.alertmanager import AlertManager
@@ -41,7 +42,7 @@ def isEnabled(state):
 
 def data_sample(CI, CC, plan_sock, path_plan_sock, thermal, calibration, health, driver_monitor,
                 poller, cal_status, cal_perc, overtemp, free_space, low_battery,
-                driver_status, state, mismatch_counter, params, plan, path_plan):
+                driver_status, state, mismatch_counter, params, plan, path_plan, time_gap):
   """Receive data from sockets and create events for battery, temperature and disk space"""
 
   # Update carstate from CAN and create events
@@ -114,7 +115,7 @@ def data_sample(CI, CC, plan_sock, path_plan_sock, thermal, calibration, health,
   return CS, events, cal_status, cal_perc, overtemp, free_space, low_battery, mismatch_counter, plan, path_plan
 
 
-def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM):
+def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, time_gap, AM):
   """Compute conditional state transitions and execute actions on state transitions"""
   enabled = isEnabled(state)
 
@@ -198,10 +199,16 @@ def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM
     elif not get_events(events, [ET.PRE_ENABLE]):
       state = State.enabled
 
-  return state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last
+  # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+  # if there has been an acc time gap button press, advance the time gap
+  for e in CS.buttonEvents:
+    if e.type == "accTimeGapButton" and e.pressed == True:
+      time_gap = TimeGaps.advance(time_gap)
+
+  return state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last, time_gap
 
 
-def state_control(plan, path_plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, AM, rk,
+def state_control(plan, path_plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, time_gap, AM, rk,
                   driver_status, LaC, LoC, VM, angle_offset, passive, is_metric, cal_perc):
   """Given the state, this function returns an actuators packet"""
 
@@ -280,7 +287,7 @@ def state_control(plan, path_plan, CS, CP, state, events, v_cruise_kph, v_cruise
   return actuators, v_cruise_kph, driver_status, angle_offset, v_acc_sol, a_acc_sol
 
 
-def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, rk, carstate,
+def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, time_gap, rk, carstate,
               carcontrol, live100, AM, driver_status,
               LaC, LoC, angle_offset, passive, start_time, params, v_acc, a_acc):
   """Send actuators and hud commands to the car, send live100 and MPC logging"""
@@ -295,6 +302,11 @@ def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruis
 
     CC.cruiseControl.override = True
     CC.cruiseControl.cancel = not CP.enableCruise or (not isEnabled(state) and CS.cruiseState.enabled)
+
+    # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    # check and see if the time gap set in the car matches the one we want from the controlsd thread
+    # if they diverge, send tell the car to update itself
+    CC.cruiseControl.advanceTimeGap = CS.cruiseState.timeGap != "unknown" and CS.cruiseState.timeGap != time_gap
 
     # Some override values for Honda
     brake_discount = (1.0 - clip(actuators.brake * 3., 0.0, 1.0))  # brake discount removes a sharp nonlinearity
@@ -454,6 +466,9 @@ def controlsd_thread(gctx=None, rate=100):
   mismatch_counter = 0
   low_battery = False
 
+  # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+  time_gap = TimeGaps.FAR
+
   plan = messaging.new_message()
   plan.init('plan')
   path_plan = messaging.new_message()
@@ -478,7 +493,7 @@ def controlsd_thread(gctx=None, rate=100):
     CS, events, cal_status, cal_perc, overtemp, free_space, low_battery, mismatch_counter, plan, path_plan  =\
       data_sample(CI, CC, plan_sock, path_plan_sock, thermal, cal, health, driver_monitor,
                   poller, cal_status, cal_perc, overtemp, free_space, low_battery, driver_status,
-                  state, mismatch_counter, params, plan, path_plan)
+                  state, mismatch_counter, params, plan, path_plan, time_gap)
     prof.checkpoint("Sample")
 
     path_plan_age = (start_time - path_plan.logMonoTime) / 1e9
@@ -493,20 +508,20 @@ def controlsd_thread(gctx=None, rate=100):
 
     if not passive:
       # update control state
-      state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last = \
-        state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM)
+      state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last, time_gap = \
+        state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, time_gap, AM)
       prof.checkpoint("State transition")
 
     # Compute actuators (runs PID loops and lateral MPC)
     actuators, v_cruise_kph, driver_status, angle_offset, v_acc, a_acc = \
       state_control(plan.plan, path_plan.pathPlan, CS, CP, state, events, v_cruise_kph,
-                    v_cruise_kph_last, AM, rk, driver_status,
+                    v_cruise_kph_last, time_gap, AM, rk, driver_status,
                     LaC, LoC, VM, angle_offset, passive, is_metric, cal_perc)
 
     prof.checkpoint("State Control")
 
     # Publish data
-    CC = data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, rk, carstate, carcontrol,
+    CC = data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, time_gap, rk, carstate, carcontrol,
                    live100, AM, driver_status, LaC, LoC, angle_offset, passive, start_time, params, v_acc, a_acc)
     prof.checkpoint("Sent")
 

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -33,6 +33,39 @@ class EventTypes:
   IMMEDIATE_DISABLE = 'immediateDisable'
   PERMANENT = 'permanent'
 
+# Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+class TimeGaps:
+  FAR = 'far'
+  MEDIUM = 'medium'
+  NEAR = 'near'
+  UNKNOWN = 'unknown'
+
+  @staticmethod
+  def advance(prev_time_gap):
+    if prev_time_gap == TimeGaps.FAR: return TimeGaps.MEDIUM
+    if prev_time_gap == TimeGaps.MEDIUM: return TimeGaps.NEAR
+    if prev_time_gap == TimeGaps.NEAR: return TimeGaps.FAR
+    raise ValueError('%s is not a valid time gap value' % prev_time_gap)
+  
+  @staticmethod
+  def from_toyota_distance_lines(distance_lines):
+    """
+    Toyota DBC holds time gap in DISTANCE_LINES signal of the PCM_CRUISE_SM message.
+    Note: This is more than just the lines shown; this is the time gap setting.
+    Convert a distance lines reading to a Time Gap enum.
+    """
+    if distance_lines == 3: return TimeGaps.FAR
+    if distance_lines == 2: return TimeGaps.MEDIUM
+    if distance_lines == 1: return TimeGaps.NEAR
+    return TimeGaps.UNKNOWN
+
+  @staticmethod
+  def to_toyota_lines(time_gap):
+    """ Convert a time gap constant to the number of time gap lines to show on the HUD """
+    if time_gap == TimeGaps.FAR: return 3
+    if time_gap == TimeGaps.MEDIUM: return 2
+    if time_gap == TimeGaps.NEAR: return 1
+    raise ValueError('%s is not a valid time gap value' % time_gap)
 
 def create_event(name, types):
   event = car.CarEvent.new_message()

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -178,7 +178,6 @@ class LongitudinalMpc(object):
 
   def update(self, CS, lead, v_cruise_setpoint):
     v_ego = CS.carState.vEgo
-
     # Setup current mpc state
     self.cur_state[0].x_ego = 0.0
 


### PR DESCRIPTION
Update the Toyota OpenDBC file to accept a command from an Arduino to change the time gap setting. Update Toyota `carstate.py` to read the setting from the Arduino and send button press event to `controlsd`. Update `controlsd` to keep track of the time gap, and if the car's time gap does not match the `controlsd` time gap, send a message to update the car's setting.