### PR TITLE
Add time gap and distance cost parameters to Longitudinal MPC

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc/libmpc_py.py
+++ b/selfdrive/controls/lib/longitudinal_mpc/libmpc_py.py
@@ -36,10 +36,10 @@ def _get_libmpc(mpc_id):
     double cost;
     } log_t;
 
-    void init(double ttcCost, double distanceCost, double accelerationCost, double jerkCost);
+    void init(double ttcCost, double defaultDistanceCost, double accelerationCost, double jerkCost);
     void init_with_simulation(double v_ego, double x_l, double v_l, double a_l, double l);
     int run_mpc(state_t * x0, log_t * solution,
-                double l, double a_l_0, double follow_time);
+                double l, double a_l_0, double time_gap, double distance_cost);
     """)
 
     return (ffi, ffi.dlopen(libmpc_fn))

--- a/selfdrive/controls/lib/planner.py
+++ b/selfdrive/controls/lib/planner.py
@@ -213,7 +213,8 @@ class LongitudinalMpc(object):
     t = sec_since_boot()
     # hardcode follow time for now
     follow_time = 1.8
-    n_its = self.libmpc.run_mpc(self.cur_state, self.mpc_solution, self.a_lead_tau, a_lead, follow_time)
+    distance_cost = 0.1
+    n_its = self.libmpc.run_mpc(self.cur_state, self.mpc_solution, self.a_lead_tau, a_lead, follow_time, distance_cost)
     duration = int((sec_since_boot() - t) * 1e9)
     self.send_mpc_solution(n_its, duration)
 


### PR DESCRIPTION
`openpilot` has hardcoded values for the time gap and distance cost settings of the Longitudinal MPC planner. Update the underlying Cxx code to accept these values as parameters, and update the python code which calls the code. Scale up the time gap as the vehicle slows down, but hardcode the values in python for now.