### PR TITLE
Track time gap setting and read CAN commands to change it

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -138,6 +138,15 @@ struct CarState {
     available @2 :Bool;
     speedOffset @3 :Float32;
     standstill @4 :Bool;
+    # added to support OpenpilotButtons -- https://github.com/rhinodavid/OpenpilotButtons
+    timeGap @5 :TimeGap;
+
+    enum TimeGap {
+      unknown @0;
+      near @1;
+      medium @2;
+      far @3;
+    }
   }
 
   enum GearShifter {
@@ -150,7 +159,6 @@ struct CarState {
     low @6;
     brake @7;
   }
-
 
   # send on change
   struct ButtonEvent {
@@ -167,9 +175,12 @@ struct CarState {
       altButton1 @6;
       altButton2 @7;
       altButton3 @8;
+      # added to support OpenpilotButtons -- https://github.com/rhinodavid/OpenpilotButtons
+      accTimeGapButton @9; # button that changes how closely the ACC follows the car in front of it
     }
   }
 }
+
 
 # ******* radar state @ 20hz *******
 
@@ -235,6 +246,8 @@ struct CarControl {
     override @1: Bool;
     speedOverride @2: Float32;
     accelOverride @3: Float32;
+    # Added to support Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    advanceTimeGap @4: Bool; # True if HUD is showing wrong time gap and needs to be advanced
   }
 
   struct HUDControl {

--- a/opendbc/generator/toyota/_comma.dbc
+++ b/opendbc/generator/toyota/_comma.dbc
@@ -22,4 +22,9 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;

--- a/opendbc/lexus_is_2018_pt_generated.dbc
+++ b/opendbc/lexus_is_2018_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/lexus_rx_hybrid_2017_pt_generated.dbc
+++ b/opendbc/lexus_rx_hybrid_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_avalon_2017_pt_generated.dbc
+++ b/opendbc/toyota_avalon_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_camry_hybrid_2018_pt_generated.dbc
+++ b/opendbc/toyota_camry_hybrid_2018_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_chr_2018_pt_generated.dbc
+++ b/opendbc/toyota_chr_2018_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_chr_hybrid_2018_pt_generated.dbc
+++ b/opendbc/toyota_chr_hybrid_2018_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_corolla_2017_pt_generated.dbc
+++ b/opendbc/toyota_corolla_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_highlander_2017_pt_generated.dbc
+++ b/opendbc/toyota_highlander_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_highlander_hybrid_2018_pt_generated.dbc
+++ b/opendbc/toyota_highlander_hybrid_2018_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_prius_2017_pt_generated.dbc
+++ b/opendbc/toyota_prius_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_rav4_2017_pt_generated.dbc
+++ b/opendbc/toyota_rav4_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_rav4_hybrid_2017_pt_generated.dbc
+++ b/opendbc/toyota_rav4_hybrid_2017_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/opendbc/toyota_sienna_xle_2018_pt_generated.dbc
+++ b/opendbc/toyota_sienna_xle_2018_pt_generated.dbc
@@ -26,6 +26,11 @@ CM BO_ STEERING_IPAS_COMMA "Copy of msg 614 so we can do angle control while the
   SG_ STATE : 39|8@0+ (1,0) [0|255] "" EON
   SG_ CHECKSUM : 47|8@0+ (1,0) [0|3] "" EON
 
+ BO_ 515 OPENPILOT_BUTTONS: 8 XXX
+  SG_ ACC_TIME_GAP : 1|2@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 515 ACC_TIME_GAP "acc time gap button press commanded by https://github.com/rhinodavid/OpenpilotButtons";
+
  VAL_ 513 STATE 5 "FAULT_TIMEOUT" 4 "FAULT_STARTUP" 3 "FAULT_SCE" 2 "FAULT_SEND" 1 "FAULT_BAD_CHECKSUM" 0 "NO_FAULT" ;
 
 

--- a/selfdrive/car/toyota/carcontroller.py
+++ b/selfdrive/car/toyota/carcontroller.py
@@ -1,5 +1,6 @@
 from cereal import car
 from common.numpy_fast import clip, interp
+from common.realtime import sec_since_boot
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car import apply_toyota_steer_torque_limits
 from selfdrive.car.toyota.toyotacan import make_can_msg, create_video_target,\
@@ -123,8 +124,12 @@ class CarController(object):
 
     self.packer = CANPacker(dbc_name)
 
+    # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    # used to rate limit sending of ACC Time Gap advance commands
+    self.last_acc_advance_time = 0.
+
   def update(self, sendcan, enabled, CS, frame, actuators,
-             pcm_cancel_cmd, hud_alert, audible_alert, forwarding_camera, left_line, right_line, lead):
+             pcm_cancel_cmd, hud_alert, audible_alert, forwarding_camera, left_line, right_line, lead, advance_time_gap = False):
 
     # *** compute control surfaces ***
 
@@ -214,13 +219,24 @@ class CarController(object):
     elif ECU.APGS in self.fake_ecus:
       can_sends.append(create_ipas_steer_command(self.packer, 0, 0, True))
 
+    # added to support OpenpilotButtons -- https://github.com/rhinodavid/OpenpilotButtons
+    # check to see if the number of time gap lines displayed by the car matches the number
+    # we are trying to command. if they are different, send a distance of 1 to change the displayed number of lines
+    advance_acc_time_gap_setting = 0
+    now_time = sec_since_boot()
+    if advance_time_gap and now_time - self.last_acc_advance_time > 0.05:
+      # rate limit this to once per 0.05 seconds
+      # was getting a soft disengage from openpilot without the rate limit
+      advance_acc_time_gap_setting = 1
+      self.last_acc_advance_time = now_time
+
     # accel cmd comes from DSU, but we can spam can to cancel the system even if we are using lat only control
     if (frame % 3 == 0 and ECU.DSU in self.fake_ecus) or (pcm_cancel_cmd and ECU.CAM in self.fake_ecus):
       lead = lead or CS.v_ego < 12.    # at low speed we always assume the lead is present do ACC can be engaged
       if ECU.DSU in self.fake_ecus:
-        can_sends.append(create_accel_command(self.packer, apply_accel, pcm_cancel_cmd, self.standstill_req, lead))
+        can_sends.append(create_accel_command(self.packer, apply_accel, pcm_cancel_cmd, self.standstill_req, lead, advance_acc_time_gap_setting))
       else:
-        can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead))
+        can_sends.append(create_accel_command(self.packer, 0, pcm_cancel_cmd, False, lead, advance_acc_time_gap_setting))
 
     if CS.CP.enableGasInterceptor:
         # send exactly zero if apply_gas is zero. Interceptor will send the max between read value and apply_gas.

--- a/selfdrive/car/toyota/toyotacan.py
+++ b/selfdrive/car/toyota/toyotacan.py
@@ -64,12 +64,12 @@ def create_steer_command(packer, steer, steer_req, raw_cnt):
   return packer.make_can_msg("STEERING_LKA", 0, values)
 
 
-def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead):
+def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, distance):
   # TODO: find the exact canceling bit that does not create a chime
   values = {
     "ACCEL_CMD": accel,
     "SET_ME_X01": 1,
-    "DISTANCE": 0,
+    "DISTANCE": distance,
     "MINI_CAR": lead,
     "SET_ME_X3": 3,
     "SET_ME_1": 1,

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -16,7 +16,8 @@ from selfdrive.controls.lib.drive_helpers import learn_angle_offset, \
                                                  create_event, \
                                                  EventTypes as ET, \
                                                  update_v_cruise, \
-                                                 initialize_v_cruise
+                                                 initialize_v_cruise, \
+                                                 TimeGaps
 from selfdrive.controls.lib.longcontrol import LongControl, STARTING_TARGET_SPEED
 from selfdrive.controls.lib.latcontrol import LatControl
 from selfdrive.controls.lib.alertmanager import AlertManager
@@ -24,6 +25,7 @@ from selfdrive.controls.lib.vehicle_model import VehicleModel
 from selfdrive.controls.lib.driver_monitor import DriverStatus
 from selfdrive.controls.lib.planner import _DT_MPC
 from selfdrive.locationd.calibration_helpers import Calibration, Filter
+from sentry_sdk import capture_message
 
 ThermalStatus = log.ThermalData.ThermalStatus
 State = log.Live100Data.ControlState
@@ -114,7 +116,7 @@ def data_sample(CI, CC, plan_sock, path_plan_sock, thermal, calibration, health,
   return CS, events, cal_status, cal_perc, overtemp, free_space, low_battery, mismatch_counter, plan, path_plan
 
 
-def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM):
+def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, time_gap, AM):
   """Compute conditional state transitions and execute actions on state transitions"""
   enabled = isEnabled(state)
 
@@ -198,7 +200,14 @@ def state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM
     elif not get_events(events, [ET.PRE_ENABLE]):
       state = State.enabled
 
-  return state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last
+  # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+  # if there has been an acc time gap button press, advance the time gap
+  for e in CS.buttonEvents:
+    if e.type == "accTimeGapButton" and e.pressed == True:
+      time_gap = TimeGaps.advance(time_gap)
+      capture_message("Received acc time gap button event; time gap advanced to %s" % time_gap)
+
+  return state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last, time_gap
 
 
 def state_control(plan, path_plan, CS, CP, state, events, v_cruise_kph, v_cruise_kph_last, AM, rk,
@@ -280,7 +289,7 @@ def state_control(plan, path_plan, CS, CP, state, events, v_cruise_kph, v_cruise
   return actuators, v_cruise_kph, driver_status, angle_offset, v_acc_sol, a_acc_sol
 
 
-def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, rk, carstate,
+def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, time_gap, rk, carstate,
               carcontrol, live100, AM, driver_status,
               LaC, LoC, angle_offset, passive, start_time, params, v_acc, a_acc):
   """Send actuators and hud commands to the car, send live100 and MPC logging"""
@@ -295,6 +304,11 @@ def data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruis
 
     CC.cruiseControl.override = True
     CC.cruiseControl.cancel = not CP.enableCruise or (not isEnabled(state) and CS.cruiseState.enabled)
+
+    # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+    # check and see if the time gap set in the car matches the one we want from the controlsd thread
+    # if they diverge, send tell the car to update itself
+    CC.cruiseControl.advanceTimeGap = CS.cruiseState.timeGap != "unknown" and CS.cruiseState.timeGap != time_gap
 
     # Some override values for Honda
     brake_discount = (1.0 - clip(actuators.brake * 3., 0.0, 1.0))  # brake discount removes a sharp nonlinearity
@@ -454,6 +468,9 @@ def controlsd_thread(gctx=None, rate=100):
   mismatch_counter = 0
   low_battery = False
 
+  # Openpilot Buttons -- https://github.com/rhinodavid/OpenpilotButtons
+  time_gap = TimeGaps.FAR
+
   plan = messaging.new_message()
   plan.init('plan')
   path_plan = messaging.new_message()
@@ -493,8 +510,8 @@ def controlsd_thread(gctx=None, rate=100):
 
     if not passive:
       # update control state
-      state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last = \
-        state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, AM)
+      state, soft_disable_timer, v_cruise_kph, v_cruise_kph_last, time_gap = \
+        state_transition(CS, CP, state, events, soft_disable_timer, v_cruise_kph, time_gap, AM)
       prof.checkpoint("State transition")
 
     # Compute actuators (runs PID loops and lateral MPC)
@@ -506,7 +523,7 @@ def controlsd_thread(gctx=None, rate=100):
     prof.checkpoint("State Control")
 
     # Publish data
-    CC = data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, rk, carstate, carcontrol,
+    CC = data_send(plan, path_plan, CS, CI, CP, VM, state, events, actuators, v_cruise_kph, time_gap, rk, carstate, carcontrol,
                    live100, AM, driver_status, LaC, LoC, angle_offset, passive, start_time, params, v_acc, a_acc)
     prof.checkpoint("Sent")
 


### PR DESCRIPTION
Modify Toyota `_comma.dbc` with custom message we plan on sending from the
the Arduino, then run `gernerator.py`

Update `carstate.py` to read the acc button press CAN message and the
time gap setting from the car

Update Toyota `interface.py` to dispatch a button event on acc time gap
button press

Update `carcontroller.py` to advance the time gap setting in the car
if the commanded time gap does not match the read value

Add fields in `car.capnp` to support the time gap

Update `controlsd.py` to store the global time gap setting and to tell
the car to update the setting if it does not match the global setting